### PR TITLE
config is in app.php, add units and lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,25 @@ bin/cake migrations migrate -p Openweathermap
 
 ## Configuration
 
-Load the component into your AppController.php or any Controller you want:
+To configure the plugin you can add the openweathermap config to the config/app.php, something like:
 
 ```php
-$this->loadComponent('Openweathermap.Openweathermap', ['key' => YOURAPIKEY]);
+return [
+
+    .... (other configs before)
+
+    'Openweathermap' => [
+        // MANDATORY : Register API keys at openweathermap.org
+        'key' => 'your-sitekey',
+        // OPTIONAL : default lang for the plugin. Default to 'fr' if this config is not provided
+        'lang' => 'en',
+        // OPTIONAL : default units mesure for the plugin. Default to 'metric' if this config is not provided
+        'units' => 'metric'
+    ]
+]
 ```
 
-The API Key is mandatory, if you want an API go to the openweathermap.org and follow instructions.
+Make sure that /config/app.php file is in .gitignore. The secret key must stay secret. The API Key is mandatory, if you want an API go to the openweathermap.org and follow instructions.
 
 ## Using
 

--- a/src/Controller/Component/OpenweathermapComponent.php
+++ b/src/Controller/Component/OpenweathermapComponent.php
@@ -86,18 +86,29 @@ class OpenweathermapComponent extends Component
     ];
 
     /**
-     * Initialisation of the component
+     * startup callback
      *
-     * @param array $config Array of configuration
+     * @param \Cake\Event\Event $event Event.
      * @throws Exception If API Key is not provided
      * @return void
      */
-    public function initialize(array $config)
+    public function startup(Event $event)
     {
-        if (isset($config['key'])) {
-            $this->_defaultConfig['key'] = $config['key'];
+        $key = Configure::consume('Openweathermap.key');
+        if (isset($key) && !empty($key)) {
+            $this->config('key', $key);
         } else {
-            throw new Exception(__d('openweathermap', 'API Key must be provided'));
+            throw new \Exception(__d('openweathermap', 'API Key must be provided'));
+        }
+
+        $lang = Configure::consume('Openweathermap.lang');
+        if (isset($lang) && !empty($lang)) {
+            $this->config('lang', $lang);
+        }
+
+        $units = Configure::consume('Openweathermap.units');
+        if (isset($units) && !empty($units)) {
+            $this->config('units', $units);
         }
     }
 
@@ -197,18 +208,19 @@ class OpenweathermapComponent extends Component
      */
     protected function _buildParams($type, $vars)
     {
-        $params['APPID'] = $this->_defaultConfig['key'];
+        $params['APPID'] = $this->config('key');
+        $this->config('key', '');
 
         // Units parameter (C° of F°)
         if (is_null($vars['units'])) {
-            $params['units'] = $this->_defaultConfig['units'];
+            $params['units'] = $this->config('units');
         } else {
             $params['units'] = $vars['units'];
         }
 
         // Language parameter
         if (is_null($vars['lang'])) {
-            $params['lang'] = $this->_defaultConfig['lang'];
+            $params['lang'] = $this->config('lang');
         }
 
         // made custom query switch from the request type (geoloc, cityId, cityName)
@@ -246,7 +258,7 @@ class OpenweathermapComponent extends Component
             $client = new Client();
             $params['mode'] = $mode;
             // grab the info
-            $data = $client->get($this->_defaultConfig['url'][$type], $params);
+            $data = $client->get($this->config('url.' . $type), $params);
 
             if (!$data->isOk()) {
                 // if the grabing is a failure, we return an error

--- a/tests/TestCase/Controller/Component/OpenweathermapComponentTest.php
+++ b/tests/TestCase/Controller/Component/OpenweathermapComponentTest.php
@@ -20,9 +20,7 @@ class OpenweathermapComponentTest extends TestCase
     {
         parent::setUp();
         $registry = new ComponentRegistry();
-        $this->Openweathermap = new OpenweathermapComponent($registry, [
-            'key' => '78382hFkd09ADQKFS8FYF8Y8FY'
-        ]);
+        $this->Openweathermap = new OpenweathermapComponent($registry);
     }
 
     /**
@@ -42,7 +40,7 @@ class OpenweathermapComponentTest extends TestCase
      *
      * @return void
      */
-    public function testInitialization()
+    public function testStartup()
     {
         $this->markTestIncomplete('Not implemented yet.');
     }


### PR DESCRIPTION
I think configuration should reside in app.php. The key must stay secret and should not be in the component configuration.

Also add units and lang params that can be configured
